### PR TITLE
Sales migration legacy support for the payment method code

### DIFF
--- a/Block/Adminhtml/Order/View/Tab/Info.php
+++ b/Block/Adminhtml/Order/View/Tab/Info.php
@@ -60,7 +60,11 @@ class Info extends \Magento\Sales\Block\Adminhtml\Order\View\Tab\Info
     {
         $code = $this->getOrder()->getPayment()->getAdditionalInformation()["svea_method_code"] ?? '';
         if ($code === '') {
-            return $code;
+            // in case this payment is from the old payment module, check the old field name too
+            $code = $this->getOrder()->getPayment()->getAdditionalInformation()["sub_payment_method"] ?? '';
+            if ($code === '') {
+                return $code;
+            }
         }
 
         return $this->getPaymentMethodLabelByCode($code);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### [Unreleased]
+* Sales migration legacy support for the payment method code
+
 ### [1.0.5] - 2024-08-14
 * Prevent legacy data migration
 


### PR DESCRIPTION
- Use the old name additional information fields for migrated payments in the Admin Order page