### PR TITLE
Save the payment method from the payment verification callback

### DIFF
--- a/view/frontend/web/js/action/select-payment-method.js
+++ b/view/frontend/web/js/action/select-payment-method.js
@@ -19,6 +19,12 @@ define([
             ? extension_attributes.svea_method_group
             : null;
 
+        if (methodCode == null) {
+            getTotalsAction([]);
+            fullScreenLoader.stopLoader();
+            return;
+        }
+
         let data = {
             store: quote.getStoreCode(),
             payment_method: paymentMethod.method,


### PR DESCRIPTION
Under certain circumstances payment method was empty in the database, to prevent this get the verified payment method from the status query and save it.

While testing the previous a path to receive empty payment method into the database was discovered, changed to the javascript to not report empty payment methods.