### PR TITLE
Set Payment Pending status when redirecting to payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### [1.0.18] -
+* Set Payment Pending on order when redirecting to payment page. Magento will automatically cancel abandoned orders after set timeout, default 8 hours.
+
 ### [1.0.17] - 2024-11-27
 * Better shipping notification text for custom delivery type
 * Fix shipping notification for customized products

--- a/Controller/Index/Delayed.php
+++ b/Controller/Index/Delayed.php
@@ -75,7 +75,7 @@ class Delayed extends Action
         }
 
         if ($order->getId()) {
-            $order->setState(Order::STATE_PENDING_PAYMENT);
+            $order->setState(Order::STATE_PAYMENT_REVIEW);
             $this->orderResource->save($order);
             $this->quoteManagement->setQuoteMode($order, false);
         }

--- a/Controller/Redirect/GetPaymentData.php
+++ b/Controller/Redirect/GetPaymentData.php
@@ -15,6 +15,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Webapi\Exception;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
 use Svea\SveaPayment\Model\Order\Cancellation;
 
 class GetPaymentData extends Action implements
@@ -75,6 +76,9 @@ class GetPaymentData extends Action implements
             if (!$paymentInformation['gateway_redirect_url']) {
                 throw new InputException(\__('Invalid Payment Information.'));
             }
+            $order->setStatus(Order::STATE_PENDING_PAYMENT);
+            $order->setState(Order::STATE_PENDING_PAYMENT);
+            $this->orderRepository->save($order);
             $resultJson->setData([
                 'redirectUrl' => $paymentInformation['gateway_redirect_url'],
             ]);


### PR DESCRIPTION
Abandoned payments were left hanging as pending orders in Magento, this happens when customers goes to payment portal and then close the browser window without confirming or cancelling payment. This change sets the order to Pending Payment before redirecting customer to payment portal which means Magento will automatically cancel the order if payment is not completed within a store set timeout.