### PR TITLE
284466 set payment pending when redirecting to payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### [1.0.18] -
+* Set Payment Pending on order when redirecting to payment page. Magento will automatically cancel abandoned orders after set timeout, default 8 hours.
+
 ### [1.0.17] - 2024-11-27
 * Better shipping notification text for custom delivery type
 * Fix shipping notification for customized products

--- a/Controller/Index/Delayed.php
+++ b/Controller/Index/Delayed.php
@@ -75,7 +75,7 @@ class Delayed extends Action
         }
 
         if ($order->getId()) {
-            $order->setState(Order::STATE_PENDING_PAYMENT);
+            $order->setState(Order::STATE_PAYMENT_REVIEW);
             $this->orderResource->save($order);
             $this->quoteManagement->setQuoteMode($order, false);
         }

--- a/Controller/Index/Success.php
+++ b/Controller/Index/Success.php
@@ -97,7 +97,7 @@ class Success extends Action
         if ($e instanceof OrderNotInvoiceableException) {
             $message = \sprintf(
                 'Order cannot be updated or invoiced anymore. Current status %s and state %s',
-                $e->getOrder()->getState(),
+                $e->getOrder()->getStatus(),
                 $e->getOrder()->getState()
             );
             $this->logger->info($message);

--- a/Controller/Redirect/GetPaymentData.php
+++ b/Controller/Redirect/GetPaymentData.php
@@ -15,6 +15,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Webapi\Exception;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
 use Svea\SveaPayment\Model\Order\Cancellation;
 
 class GetPaymentData extends Action implements
@@ -75,6 +76,9 @@ class GetPaymentData extends Action implements
             if (!$paymentInformation['gateway_redirect_url']) {
                 throw new InputException(\__('Invalid Payment Information.'));
             }
+            $order->setStatus(Order::STATE_PENDING_PAYMENT);
+            $order->setState(Order::STATE_PENDING_PAYMENT);
+            $this->orderRepository->save($order);
             $resultJson->setData([
                 'redirectUrl' => $paymentInformation['gateway_redirect_url'],
             ]);

--- a/Controller/Redirect/GetPaymentData.php
+++ b/Controller/Redirect/GetPaymentData.php
@@ -76,8 +76,8 @@ class GetPaymentData extends Action implements
             if (!$paymentInformation['gateway_redirect_url']) {
                 throw new InputException(\__('Invalid Payment Information.'));
             }
-            $order->setStatus(Order::STATE_PENDING_PAYMENT);
             $order->setState(Order::STATE_PENDING_PAYMENT);
+            $order->setStatus(Order::STATE_PENDING_PAYMENT);
             $this->orderRepository->save($order);
             $resultJson->setData([
                 'redirectUrl' => $paymentInformation['gateway_redirect_url'],

--- a/Gateway/Response/Payment/ErrorHandler.php
+++ b/Gateway/Response/Payment/ErrorHandler.php
@@ -74,7 +74,7 @@ class ErrorHandler
         }
         if (in_array($order->getState(), [
             Order::STATE_PENDING_PAYMENT,
-            ORDER::STATE_NEW
+            Order::STATE_NEW
         ])) {
             if (isset($requestParams['type']) && $requestParams['type'] === self::ERROR_SELLERCOSTS_VALUES_MISMATCH) {
                 $order->addCommentToStatusHistory(

--- a/Model/Order/Status/Query/OrderCollector.php
+++ b/Model/Order/Status/Query/OrderCollector.php
@@ -3,6 +3,7 @@
 namespace Svea\SveaPayment\Model\Order\Status\Query;
 
 use DateTimeInterface;
+use Magento\Sales\Model\Order;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use Svea\SveaPayment\Gateway\Config\Config;
 use Svea\SveaPayment\Model\Payment\Method;
@@ -49,7 +50,7 @@ class OrderCollector
     {
         $collection = $this->ordersFactory->create();
         $collection->join(['payment' => 'sales_order_payment'], 'main_table.entity_id=parent_id', 'method')
-            ->addFieldToFilter('status', $this->config->getNewOrderStatus())
+            ->addFieldToFilter('status', ['in' => [$this->config->getNewOrderStatus(), Order::STATE_PENDING_PAYMENT]])
             ->addFieldToFilter('payment.method', $this->paymentMethod->getSveaCollectionFilter())
             ->addFieldToFilter('payment.' . Config::SVEA_SELLER_IR, $this->config->getSellerId())
             ->addAttributeToFilter('created_at', ['gteq' => $this->formatDate($createdStart)])
@@ -68,7 +69,7 @@ class OrderCollector
     {
         $collection = $this->ordersFactory->create();
         $collection->join(['payment' => 'sales_order_payment'], 'main_table.entity_id=parent_id', 'method')
-            ->addFieldToFilter('status', $this->config->getNewOrderStatus())
+            ->addFieldToFilter('status', ['in' => [$this->config->getNewOrderStatus(), Order::STATE_PENDING_PAYMENT]])
             ->addFieldToFilter('payment.method', $this->paymentMethod->getMaksuturvaCollectionFilter())
             ->addAttributeToFilter('created_at', ['gteq' => $this->formatDate($createdStart)])
             ->addAttributeToFilter('created_at', ['lt' => $this->formatDate($createdEnd)]);

--- a/Model/Order/Status/Query/ResponseHandler.php
+++ b/Model/Order/Status/Query/ResponseHandler.php
@@ -111,7 +111,8 @@ class ResponseHandler
                         }
                     } else {
                         /* resolve case when invoice exists but status in database is still pending payment */
-                        if ($order->getStatus() == $this->config->getNewOrderStatus()) {
+                        if ($order->getState() == Order::STATE_PENDING_PAYMENT ||
+                            $order->getStatus() == $this->config->getNewOrderStatus()) {
                             $this->setOrderAsPaid($order, \__('Payment confirmed by Svea Payments.'));
                         }
                         $result->setCode(Status::CODE_SUCCESS)


### PR DESCRIPTION
Improved version of payment pending change based on feedback. If customers close browser after progressing to Svea payments portal but before returning to store order is left in limbo forever, this sets the order to STATE_PENDING_PAYMENT before redirecting so Magento will automatically cancel them if it is not completed in the set timeout (8 hours default), setting found under _store_ > _sales_ > _orders cron setting_ and is set in minutes, 1440 for a day, 10080 for a week.

This updated version handles orders that were created previously if they are completed, abandoned orders still need to be manually removed, recommend using Magento orders view and filter on **status** pending and **to** week ago.