### PR TITLE
Fix virtual products not being purchaseable due to missing shipping address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### [1.0.18] -
+* Fixed digital only products were purchaseable because of missing shipping address.
+
 ### [1.0.17] - 2024-11-27
 * Better shipping notification text for custom delivery type
 * Fix shipping notification for customized products

--- a/Gateway/Request/AddressDataBuilder.php
+++ b/Gateway/Request/AddressDataBuilder.php
@@ -50,21 +50,22 @@ class AddressDataBuilder implements BuilderInterface
     public function build(array $buildSubject): array
     {
         $paymentDO = $this->subjectReader ->readPayment($buildSubject);
-
         $order = $paymentDO->getOrder();
-        $result = [];
-
-        $shippingAddress = $order->getShippingAddress();
-        if ($shippingAddress) {
-            $result = [
-                self::DELIVERY_NAME => $shippingAddress->getFirstname() . " " . $shippingAddress->getLastname(),
-                self::DELIVERY_ADDRESS => $shippingAddress->getStreetLine1(),
-                self::DELIVERY_POSTAL_CODE => $shippingAddress->getPostcode(),
-                self::DELIVERY_CITY => $shippingAddress->getCity(),
-                self::DELIVERY_COUNTRY => $shippingAddress->getCountryId(),
-            ];
+        $address = $order->getShippingAddress();
+        if (!$address) {
+            $address = $order->getBillingAddress();
+        }
+        if (!$address) {
+            throw new \Exception("Shipping or billing address was not provided, cannot process order.");
         }
 
+        $result = [
+            self::DELIVERY_NAME => $address->getFirstname() . " " . $address->getLastname(),
+            self::DELIVERY_ADDRESS => $address->getStreetLine1(),
+            self::DELIVERY_POSTAL_CODE => $address->getPostcode(),
+            self::DELIVERY_CITY => $address->getCity(),
+            self::DELIVERY_COUNTRY => $address->getCountryId(),
+        ];
         return $result;
     }
 }


### PR DESCRIPTION
If only a virtual product is in the basket the shipping address is not set, this caused failure as required fields were not filled in. Change so that we use billing address if shipping address is not set and fail early if neither is set.