### PR TITLE
294819 Better handling of null fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### [1.1.1] -
+* Better handling of null fields on old orders.
+
 ### [1.1.0] - 2025-03-17
 * Set Payment Pending on order when redirecting to payment page. Magento will automatically cancel abandoned orders after set timeout, default 8 hours.
 * Uniform handling of return urls

--- a/Model/Sales/Total/HandlingFee.php
+++ b/Model/Sales/Total/HandlingFee.php
@@ -17,11 +17,11 @@ class HandlingFee
     /**
      * @param DataObject $model
      *
-     * @return float|null
+     * @return float
      */
-    public function getValue(DataObject $model)
+    public function getValue(DataObject $model): float
     {
-        return $model->getData(self::CODE);
+        return $model->getData(self::CODE) ?? 0;
     }
 
     /**
@@ -38,16 +38,16 @@ class HandlingFee
     /**
      * @param DataObject $model
      *
-     * @return float|null
+     * @return float
      */
-    public function getRefundedValue(DataObject $model)
+    public function getRefundedValue(DataObject $model): float
     {
-        return $model->getData(self::REFUNDED_CODE);
+        return $model->getData(self::REFUNDED_CODE) ?? 0;
     }
 
-    public function getRefundedTaxValue(DataObject $model)
+    public function getRefundedTaxValue(DataObject $model): float
     {
-        return $model->getData(self::REFUNDED_TAX_CODE);
+        return $model->getData(self::REFUNDED_TAX_CODE) ?? 0;
     }
 
     /**


### PR DESCRIPTION
On orders created before Svea Payments module was installed some fields relating to Svea fees remain as null, this change handles them as 0 when doing totals calculations for Magento.