### PR TITLE
296175 row specification on partial refunds

### DIFF
--- a/Gateway/Request/Refund/PaymentCancelDataBuilder.php
+++ b/Gateway/Request/Refund/PaymentCancelDataBuilder.php
@@ -6,6 +6,8 @@ use Exception;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Payment\Model\InfoInterface;
 use Magento\Sales\Model\Order\Payment;
+use Magento\Sales\Model\Order\Creditmemo;
+use Magento\Sales\Model\Order\Creditmemo\Item;
 use Svea\SveaPayment\Gateway\Command\RefundCommand;
 use Svea\SveaPayment\Gateway\Config\Config;
 use Svea\SveaPayment\Gateway\Data\AmountHandler;
@@ -69,6 +71,10 @@ class PaymentCancelDataBuilder implements BuilderInterface
         /** If not full refund, add cancel amount */
         if ($cancelType !== 'FULL_REFUND') {
             $data['pmtc_cancelamount'] = $this->amountHandler->formatFloat($refundAmount);
+            $creditmemo = $payment->getCreditmemo();
+            $N = $this->addDiscountRow($data, $creditmemo);
+            $this->addShippingRow($data, $creditmemo, $N);
+            $N = $this->addItemRows($data, $creditmemo, $N);
         }
         /** Add IBAN number to REFUND_AFTER_SETTLEMENT cases */
         if ($cancelType === RefundCommand::CANCEL_TYPE_REFUND_AFTER_SETTLEMENT) {
@@ -76,6 +82,61 @@ class PaymentCancelDataBuilder implements BuilderInterface
         }
 
         return $data;
+    }
+
+    /**
+     * Discount must be accounted for in the number of rows as it was sent in the original order.
+     * But we will not refund the original row, but rather add a new row with the adjustment, discount is always negative.
+     */
+    private function addDiscountRow(array &$data, Creditmemo $creditmemo): int
+    {
+        if ($creditmemo->getOrder()->getDiscountAmount() < 0) {
+            $data['pmtc_additional_row_name1'] = 'Discount';
+            $data['pmtc_additional_row_desc1'] = 'Discount reduction';
+            $data['pmtc_additional_row_quantity1'] = 1;
+            $data['pmtc_additional_row_price_gross1'] = $this->amountHandler->formatFloat(-$creditmemo->getBaseDiscountAmount());
+            $data['pmtc_additional_row_vat1'] = $this->amountHandler->formatFloat(0);
+            return 2;
+        }
+        return 1;
+    }
+
+    /**
+     * Refund the items with quantity greater than 0 from the credit memo, order needs to be the same as orignal order.
+     * Configurable products are accounted for in that we skip the simple subitems
+     */
+    private function addItemRows(array &$data, Creditmemo $creditmemo, int $N): int
+    {
+        /** @var Item $item */
+        foreach ($creditmemo->getItems() as $item) {
+            $orderItem = $item->getOrderItem();
+            /* Skip the simple subitems of configurable products */
+            if ($orderItem->getProductType() === 'simple' && $orderItem->getParentItem() !== null) {
+                continue;
+            }
+            if ($item->getQty() > 0) {
+                $data["pmtc_refund_quantity_of_original_row{$N}"] = $this->amountHandler->formatFloat($item->getQty());
+            }
+            $N += 1;
+        }
+
+        return $N;
+    }
+
+    /**
+     * If shipping is refunded, add a additional row for it
+     */
+    private function addShippingRow(array &$data, Creditmemo $creditmemo, int $N): void
+    {
+        if ($creditmemo->getBaseShippingAmount() > 0) {
+            $shippingNet = $creditmemo->getBaseShippingAmount();
+            $vat = (\round(($creditmemo->getBaseShippingTaxAmount() / $shippingNet) * 100 * 2) / 2);
+            $data["pmtc_additional_row_name{$N}"] = 'Shipping';
+            $data["pmtc_additional_row_desc{$N}"] = 'Shipping refund';
+            $data["pmtc_additional_row_quantity{$N}"] = 1;
+            $data["pmtc_additional_row_price_gross{$N}"] = $this->amountHandler->formatFloat(-$creditmemo->getBaseShippingInclTax());
+            $data["pmtc_additional_row_vat{$N}"] = $this->amountHandler->formatFloat($vat);
+        }
     }
 
     /**


### PR DESCRIPTION
When doing partial refunds provide a row specification to be able to calculate VAT correctly. Correlate returned items with their rows in the original order and add extra rows for unit-less things like shipping, handling, and other fees and adjustments.

Tested that calculates correctly for the following kinds of orders and returns
* free shipping
* shipping not returned
* shipping partially returned
* shipping returned
* doing more than one refund on the same order
* order with general discount
* order with discounted item
* order with invoicing fee
* creditmemo adjustments