### PR TITLE
Use gross instead of net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Svea interface changed to use gross values instead of net prices.
+
 ### [1.3.1] - 2025-08-28
 * Fixed duplicate collated payment method titles on the checkout page.
 * Added option to use custom API endpoint url for communication.

--- a/Gateway/Data/AmountHandler.php
+++ b/Gateway/Data/AmountHandler.php
@@ -23,6 +23,9 @@ class AmountHandler
      */
     public function formatFloat($amount): string
     {
-        return \str_replace('.', ',', \sprintf('%.2f', $amount));
+        if (is_null($amount)) {
+            return "0.00";
+        }
+        return number_format($amount, 2, ',', '');
     }
 }

--- a/Gateway/Data/Order/OrderAdapter.php
+++ b/Gateway/Data/Order/OrderAdapter.php
@@ -106,14 +106,14 @@ class OrderAdapter implements OrderAdapterInterface
         return $this->order->getBaseDiscountAmount();
     }
 
-    public function getBaseShippingAmount(): ?float
-    {
-        return $this->order->getBaseShippingAmount();
-    }
-
     public function getDiscountDescription(): ?string
     {
         return $this->order->getDiscountDescription();
+    }
+
+    public function getBaseShippingAmountInclTax(): ?float
+    {
+        return $this->order->getBaseShippingInclTax();
     }
 
     public function getShippingDescription(): ?string
@@ -121,9 +121,18 @@ class OrderAdapter implements OrderAdapterInterface
         return $this->order->getShippingDescription();
     }
 
-    public function getBaseShippingTaxAmount()
+    public function getShippingTaxRate(): string  
     {
-        return $this->order->getBaseShippingTaxAmount();
+        $extensionAttributes = $this->order->getExtensionAttributes();
+        $itemAppliedTaxes = $extensionAttributes->getItemAppliedTaxes() ?? [];
+        foreach ($itemAppliedTaxes as $appliedTaxForItem) {
+            if ($appliedTaxForItem->getType() === "shipping") {
+                foreach ($appliedTaxForItem->getAppliedTaxes() ?? [] as $taxLineItem) {
+                    return $taxLineItem->getDataByKey('percent');
+                }
+            }
+        }
+        return "0.0";
     }
 
     public function getBaseGiftCardAmount(): ?float

--- a/Gateway/Request/RowData/DiscountRowBuilder.php
+++ b/Gateway/Request/RowData/DiscountRowBuilder.php
@@ -75,7 +75,7 @@ class DiscountRowBuilder implements RowBuilderInterface
                     self::DESC => $description,
                     self::QUANTITY => 1,
                     self::DELIVERY_DATE => date('d.m.Y'),
-                    self::PRICE_NET => $this->amountHandler->formatFloat($discount_data['net']),
+                    self::PRICE_GROSS => $this->amountHandler->formatFloat($discount_data['gross']),
                     self::VAT => $vat,
                     self::DISCOUNT_PERCENTAGE => '0,00',
                     self::TYPE => 6,

--- a/Gateway/Request/RowData/GiftCardRowBuilder.php
+++ b/Gateway/Request/RowData/GiftCardRowBuilder.php
@@ -55,7 +55,7 @@ class GiftCardRowBuilder implements RowBuilderInterface
     }
 
     /**
-     * Discount type row pmt_row_price_net is always negative
+     * Discount type row pmt_row_price_gross is always negative
      *
      * @param float $amount
      *
@@ -68,7 +68,7 @@ class GiftCardRowBuilder implements RowBuilderInterface
             self::DESC => __('Gift Card'),
             self::QUANTITY => 1,
             self::DELIVERY_DATE => date('d.m.Y'),
-            self::PRICE_NET => $this->amountHandler->formatFloat(-$amount),
+            self::PRICE_GROSS => $this->amountHandler->formatFloat(-$amount),
             self::VAT => $this->amountHandler->formatFloat(0),
             self::DISCOUNT_PERCENTAGE => $this->amountHandler->formatFloat(0),
             self::TYPE => 6,

--- a/Gateway/Request/RowData/HandlingFeeRowBuilder.php
+++ b/Gateway/Request/RowData/HandlingFeeRowBuilder.php
@@ -59,7 +59,7 @@ class HandlingFeeRowBuilder implements RowBuilderInterface
                 self::DESC => \__('Invoicing Fee'),
                 self::QUANTITY => 1,
                 self::DELIVERY_DATE => \date('d.m.Y'),
-                self::PRICE_NET => $this->amountHandler->formatFloat($amount),
+                self::PRICE_GROSS => $this->amountHandler->formatFloat($amount + $taxAmount),
                 self::VAT => $this->amountHandler->formatFloat($taxPercent),
                 self::DISCOUNT_PERCENTAGE => $this->amountHandler->formatFloat(0),
                 self::TYPE => 3,

--- a/Gateway/Request/RowData/HandlingFeeRowBuilder.php
+++ b/Gateway/Request/RowData/HandlingFeeRowBuilder.php
@@ -45,11 +45,11 @@ class HandlingFeeRowBuilder implements RowBuilderInterface
     public function build(array $buildSubject, float $totalAmount, float $sellerCosts): array
     {
         $paymentDO = $this->subjectReader->readPayment($buildSubject);
-        $payment = $paymentDO->getPayment();
+        $dataObject = $paymentDO->getPayment()->getOrder();
 
-        $amount = $this->handlingFee->getValue($payment->getOrder());
-        $taxAmount = $this->handlingFee->getTaxAmount($payment->getOrder());
-        $taxPercent = $taxAmount > 0 ? $this->handlingFee->getTaxAmountPercentage($payment->getOrder()) : 0;
+        $amount = $this->handlingFee->getValue($dataObject);
+        $taxAmount = $this->handlingFee->getTaxAmount($dataObject);
+        $taxPercent = $taxAmount > 0 ? $this->handlingFee->getTaxAmountPercentage($dataObject) : 0;
 
         $row = [];
 

--- a/Gateway/Request/RowData/ProductRowBuilder.php
+++ b/Gateway/Request/RowData/ProductRowBuilder.php
@@ -62,7 +62,7 @@ class ProductRowBuilder implements RowBuilderInterface
                 self::QUANTITY => $this->amountHandler->formatFloat($item->getQtyToInvoice()),
                 self::ARTICLE_NUMBER => $sku,
                 self::DELIVERY_DATE => date('d.m.Y'),
-                self::PRICE_NET => $this->amountHandler->formatFloat($item->getBasePrice()),
+                self::PRICE_GROSS => $this->amountHandler->formatFloat($item->getBasePriceInclTax()),
                 self::VAT => $this->amountHandler->formatFloat($item->getTaxPercent()),
                 self::DISCOUNT_PERCENTAGE => '0,00',
                 self::TYPE => 1,

--- a/Gateway/Request/RowData/ShippingRowBuilder.php
+++ b/Gateway/Request/RowData/ShippingRowBuilder.php
@@ -2,14 +2,8 @@
 
 namespace Svea\SveaPayment\Gateway\Request\RowData;
 
-use Magento\Checkout\Model\Session;
-use Magento\Customer\Model\ResourceModel\GroupRepository;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
-use Magento\Tax\Helper\Data as TaxHelper;
-use Magento\Tax\Model\Calculation;
 use Svea\SveaPayment\Gateway\Data\AmountHandler;
-use Svea\SveaPayment\Gateway\Data\Order\OrderAdapterFactory;
 use Svea\SveaPayment\Gateway\Request\RowBuilderInterface;
 use Svea\SveaPayment\Gateway\SubjectReaderInterface;
 use function __;
@@ -20,36 +14,6 @@ class ShippingRowBuilder implements RowBuilderInterface
      * @var SubjectReaderInterface
      */
     private $subjectReader;
-
-    /**
-     * @var TaxHelper
-     */
-    private $taxHelper;
-
-    /**
-     * @var Calculation
-     */
-    private $calculationModel;
-
-    /**
-     * @var Session
-     */
-    private $checkoutSession;
-
-    /**
-     * @var ScopeConfigInterface
-     */
-    private $scopeConfig;
-
-    /**
-     * @var GroupRepository
-     */
-    private $groupRepository;
-
-    /**
-     * @var OrderAdapterFactory
-     */
-    private $orderAdapterFactory;
 
     /**
      * @var TimezoneInterface
@@ -63,22 +27,10 @@ class ShippingRowBuilder implements RowBuilderInterface
 
     public function __construct(
         SubjectReaderInterface $subjectReader,
-        TaxHelper $taxHelper,
-        Calculation $calculationModel,
-        Session $checkoutSession,
-        ScopeConfigInterface $scopeConfig,
-        GroupRepository $groupRepository,
-        OrderAdapterFactory $orderAdapterFactory,
         TimezoneInterface $timezone,
         AmountHandler $amountHandler
     ) {
         $this->subjectReader  = $subjectReader;
-        $this->taxHelper = $taxHelper;
-        $this->calculationModel = $calculationModel;
-        $this->checkoutSession = $checkoutSession;
-        $this->scopeConfig = $scopeConfig;
-        $this->groupRepository = $groupRepository;
-        $this->orderAdapterFactory = $orderAdapterFactory;
         $this->timezone = $timezone;
         $this->amountHandler = $amountHandler;
     }
@@ -92,56 +44,26 @@ class ShippingRowBuilder implements RowBuilderInterface
         $orderAdapter = $paymentDO->getOrder();
 
         $shippingDescription = $orderAdapter->getShippingDescription() ?: 'Free Shipping';
-        $shippingCost = $orderAdapter->getBaseShippingAmount() ?? 0.0;
-        $taxId = $this->taxHelper->getShippingTaxClass($orderAdapter->getStoreId());
-        $request = $this->calculationModel->getRateRequest();
-
-        $request->setCustomerClassId($this->getCustomerTaxClass())->setProductClassId($taxId);
-
-        $shippingTax = $orderAdapter->getBaseShippingTaxAmount() ?? 0;
-        $shippingTaxRate = $this->getShippingTaxRate($shippingTax, $shippingCost);
+        $shippingInclTax = $orderAdapter->getBaseShippingAmountInclTax();
+        $shippingTaxRate = $orderAdapter->getShippingTaxRate();
 
         $row = [
             self::NAME => __('Shipping'),
             self::DESC => $shippingDescription,
             self::QUANTITY => 1,
             self::DELIVERY_DATE => $this->timezone->date()->format('d.m.Y'),
-            self::PRICE_GROSS => $this->amountHandler->formatFloat($shippingCost + $shippingTax),
+            self::PRICE_GROSS => $this->amountHandler->formatFloat($shippingInclTax),
             self::VAT => $this->amountHandler->formatFloat($shippingTaxRate),
             self::DISCOUNT_PERCENTAGE => '0,00',
             self::TYPE => 2,
         ];
 
-        $sellerCosts += $shippingCost + $shippingTax;
+        $sellerCosts += $shippingInclTax;
 
         return [
             self::TOTAL_AMOUNT => $totalAmount,
             self::SELLER_COSTS => $sellerCosts,
             self::ROW => $row,
         ];
-    }
-
-    private function getCustomerTaxClass(): int
-    {
-        $customerGroup = $this->checkoutSession->getQuote()->getCustomerGroupId();
-        if (!$customerGroup) {
-            $customerGroup = $this->scopeConfig->getValue('customer/create_account/default_group');
-        }
-
-        return $this->groupRepository->getById($customerGroup)->getTaxClassId();
-    }
-
-    /**
-     * @param float $shippingTax
-     * @param float $shippingCost
-     * @return float|int
-     */
-    private function getShippingTaxRate(float $shippingTax, float $shippingCost)
-    {
-        if ($shippingCost === 0.0) {
-            return 0;
-        }
-
-        return (float)(\round(($shippingTax / $shippingCost) * 100 * 2) / 2);
     }
 }

--- a/Gateway/Request/RowData/ShippingRowBuilder.php
+++ b/Gateway/Request/RowData/ShippingRowBuilder.php
@@ -106,7 +106,7 @@ class ShippingRowBuilder implements RowBuilderInterface
             self::DESC => $shippingDescription,
             self::QUANTITY => 1,
             self::DELIVERY_DATE => $this->timezone->date()->format('d.m.Y'),
-            self::PRICE_NET => $this->amountHandler->formatFloat($shippingCost),
+            self::PRICE_GROSS => $this->amountHandler->formatFloat($shippingCost + $shippingTax),
             self::VAT => $this->amountHandler->formatFloat($shippingTaxRate),
             self::DISCOUNT_PERCENTAGE => '0,00',
             self::TYPE => 2,

--- a/Gateway/Response/Payment/SuccessHandler.php
+++ b/Gateway/Response/Payment/SuccessHandler.php
@@ -365,7 +365,14 @@ class SuccessHandler
             }
         }
 
-        if ($request['pmt_sellercosts'] > $response['pmt_sellercosts']) {
+        $requestSanitized = str_replace(',', '.', str_replace(' ', '', $request['pmt_sellercosts']));
+        $responseSanitized = str_replace(',', '.', str_replace(' ', '', $response['pmt_sellercosts']));
+
+        // Convert the sanitized strings to floats
+        $requestSellercosts = (float) $requestSanitized;
+        $responseSellercosts = (float) $responseSanitized;
+
+        if ($requestSellercosts > $responseSellercosts) {
             $this->logger->error($this->formatLogMessage(
                 \sprintf(
                     'Sellercost mismatch: request "%s" != response "%s"',

--- a/Gateway/Response/Payment/SuccessHandler.php
+++ b/Gateway/Response/Payment/SuccessHandler.php
@@ -410,9 +410,16 @@ class SuccessHandler
         $isDelayedCapture = $this->methods->isDelayedCapture($response['pmt_paymentmethod']);
         $statusText = $isDelayedCapture ? 'authorized' : 'captured';
 
+        $requestSanitized = str_replace(',', '.', str_replace(' ', '', $request['pmt_sellercosts']));
+        $responseSanitized = str_replace(',', '.', str_replace(' ', '', $response['pmt_sellercosts']));
+
+        // Convert the sanitized strings to floats
+        $requestSellercosts = (float) $requestSanitized;
+        $responseSellercosts = (float) $responseSanitized;
+
         // extrapaymentmethodfee has potentially caused sellercosts changes -> include notice to message
-        if ($request['pmt_sellercosts'] != $response['pmt_sellercosts']) {
-            $sellercostsChange = $response['pmt_sellercosts'] - $request['pmt_sellercosts'];
+        if ($requestSellercosts != $responseSellercosts) {
+            $sellercostsChange = $responseSellercosts - $requestSellercosts;
             if ($sellercostsChange > 0) {
                 $msg = \__(
                     "Payment %1 by Svea Payments. NOTE: Change in the sellercosts + %2 EUR.",

--- a/Model/Request/RowDataValidator.php
+++ b/Model/Request/RowDataValidator.php
@@ -112,7 +112,7 @@ class RowDataValidator
 
         // If price is fully dynamic
         if ($item->getProduct()->getPriceType() == 0) {
-            $row[RowBuilderInterface::PRICE_NET] = str_replace('.', ',', sprintf("%.2f", '0'));
+            $row[RowBuilderInterface::PRICE_GROSS] = str_replace('.', ',', sprintf("%.2f", '0'));
         } else {
             $totalAmount += $itemData["price_incl_tax"] * $item->getQtyOrdered();
         }

--- a/Model/Request/RowDataValidator.php
+++ b/Model/Request/RowDataValidator.php
@@ -50,7 +50,7 @@ class RowDataValidator
             return $this->bundleRows($item, $totalAmount, $itemData, $row);
         }
 
-        $totalAmount += $itemData['base_price_incl_tax'] * $item->getQtyToInvoice();
+        $totalAmount += $itemData['base_row_total_incl_tax'];
 
         return [
             RowBuilderInterface::TOTAL_AMOUNT => $totalAmount,
@@ -91,7 +91,7 @@ class RowDataValidator
             $row[RowBuilderInterface::DESC] = $childSku;
         }
 
-        $totalAmount += $itemData["base_price_incl_tax"] * $item->getQtyToInvoice();
+        $totalAmount += $itemData["base_row_total_incl_tax"];
 
         return [
             RowBuilderInterface::TOTAL_AMOUNT => $totalAmount,
@@ -114,7 +114,7 @@ class RowDataValidator
         if ($item->getProduct()->getPriceType() == 0) {
             $row[RowBuilderInterface::PRICE_GROSS] = str_replace('.', ',', sprintf("%.2f", '0'));
         } else {
-            $totalAmount += $itemData["price_incl_tax"] * $item->getQtyOrdered();
+            $totalAmount += $itemData["base_row_total_incl_tax"];
         }
 
         $row['pmt_row_type'] = 4;
@@ -140,7 +140,7 @@ class RowDataValidator
 
         $row[RowBuilderInterface::NAME] = $unitQty . " X " . $parentQty . " X " . $item->getName();
         $row[RowBuilderInterface::QUANTITY] = str_replace('.', ',', sprintf("%.2f", $item->getQtyOrdered()));
-        $totalAmount += $itemData["base_price_incl_tax"] * $item->getQtyOrdered();
+        $totalAmount += $itemData["base_row_total_incl_tax"];
         $row['pmt_row_type'] = 4;
 
         return [


### PR DESCRIPTION
This change integrates some suggestions from PR#44 but the main objective is to change use of Svea API from the deprecated net prices to gross prices.

The biggest change had to happen in discounts as the whole logic changed, we now work from Magentos change in row total to calculate the size of gross discount. This is sent as gross amount so net discount and VAT amount may differ on Svea Extranet as Magento calculates it in a way that cannot be translated over the current API, but payment total and gross sums will add up.

If Magento is configured to tax calculation Total or Row Total instead of Unit Price there may be rounding rows on Svea Extranet this is more likely to appear when having large quantities of singular items in the order.