### PR TITLE
Error in FetchPaymentMethods

### DIFF
--- a/Controller/Checkout/FetchPaymentMethods.php
+++ b/Controller/Checkout/FetchPaymentMethods.php
@@ -57,8 +57,13 @@ class FetchPaymentMethods extends Action
     {
         $this->storeManager->setCurrentStore($this->getRequest()->getParam('store'));
         $quote = $this->checkoutSession->getQuote();
-        $method = $quote->getPayment()->getMethodInstance();
-        $methods = $this->methodCollector->getAvailableQuoteMethods($method, $quote);
+
+        if ($quote->getPayment()->getPaymentMethod() === null) {
+            $methods = [];
+        } else {
+            $method = $quote->getPayment()->getMethodInstance();
+            $methods = $this->methodCollector->getAvailableQuoteMethods($method, $quote);
+        }
 
         return $this->jsonFactory->create()->setData($methods);
     }


### PR DESCRIPTION
Frontend calls FetchPaymentMethods on checkout page, but if Svea is not default method we get a null. This causes an 'The payment method you requested is not available.' error. Handle not being set as default payment method.

Steps to reproduce: ( Thanks to joelvai )

1. Configure 2 different payment methods out of which the second one is SVEA's `Redirect to Svea's Payment Method Selection Page` and the other one any Magento's default.
2. Add anything to cart and proceed to checkout
3. Fill Shipping information and select any shipping method
4. Proceed to Payment page and keep eye on the Network tab
5. When no payment method is selected, select the SVEA payment method first => error
a. Alternatively select the Magento's payment method and even if you refresh the page and then select SVEA the error appears