### PR TITLE
Fix Svea payment methods paddings with One Page Checkout extension

### DIFF
--- a/view/frontend/web/css/source/icons_form_collated.css
+++ b/view/frontend/web/css/source/icons_form_collated.css
@@ -1,3 +1,13 @@
+/* Fix paddings when displayed through One Page Checkout extension */
+.opc-wrapper .svea-payment-methods {
+    padding: 0;
+}
+@media screen and (min-width: 768px) {
+    .opc-wrapper .svea-payment-methods {
+        margin-left: -20px;
+    }
+}
+
 .svea-payment-methods .sub-method-title {
     width: 100%;
     clear: both;


### PR DESCRIPTION
Tested with all OPC layouts with both default styles (and checked that it doesn't break original checkout).