### PR TITLE
Fixed console error 'Payment data URL is undefined'

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/svea-collated-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/svea-collated-method.js
@@ -175,9 +175,11 @@ define([
 
         afterPlaceOrder: function () {
             let self = this;
-            if (typeof svea_payment === "undefined" || svea_payment === null) {
+
+            if (typeof this.checkoutConfig.paymentDataUrl === "undefined" || this.checkoutConfig.paymentDataUrl === null) {
                 console.error('Payment data URL is undefined')
             }
+
             customerData.invalidate(['cart']);
 
             $.post(this.checkoutConfig.paymentDataUrl)

--- a/view/frontend/web/js/view/payment/method-renderer/svea_payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/svea_payment.js
@@ -153,10 +153,13 @@ define([
 
         afterPlaceOrder: function () {
             let self = this;
-            if (typeof svea_payment === "undefined" || svea_payment === null) {
+
+            if (typeof this.checkoutConfig.paymentDataUrl === "undefined" || this.checkoutConfig.paymentDataUrl === null) {
                 console.error('Payment data URL is undefined')
             }
+
             customerData.invalidate(['cart']);
+
             $.post(this.checkoutConfig.paymentDataUrl)
                 .done(function (response) {
                     window.location.replace(response.redirectUrl);


### PR DESCRIPTION
Problem: looks like variable svea_payment is not defined so this console error is always logged in checkout: console.error('Payment data URL is undefined')

Removed svea_payment variable check. It seems that this.checkoutConfig.paymentDataUrl is what's really used for Payment Data URL.

Relating to this issue: https://github.com/maksuturva/magento2_svea_payments/issues/54