### PR TITLE
Add svea_handling_fee and tax to creditmemo in database

### DIFF
--- a/Model/Creditmemo/Total/HandlingFee.php
+++ b/Model/Creditmemo/Total/HandlingFee.php
@@ -48,6 +48,7 @@ class HandlingFee extends AbstractTotal
             $desiredAmount = $allowedAmount;
         }
         $this->handlingFee->setValue($creditmemo, $desiredAmount);
+        $this->handlingFee->setBaseValue($creditmemo, $desiredAmount);
         $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $desiredAmount);
         $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $desiredAmount);
 

--- a/Model/Creditmemo/Total/HandlingFeeTax.php
+++ b/Model/Creditmemo/Total/HandlingFeeTax.php
@@ -48,6 +48,7 @@ class HandlingFeeTax extends AbstractTotal
             $desiredAmount = $allowedAmount;
         }
         $this->handlingFee->setTaxAmount($creditmemo, $desiredAmount);
+        $this->handlingFee->setBaseTaxAmount($creditmemo, $desiredAmount);
         $creditmemo->setGrandTotal($creditmemo->getGrandTotal() + $desiredAmount);
         $creditmemo->setBaseGrandTotal($creditmemo->getBaseGrandTotal() + $desiredAmount);
 

--- a/Model/Order/CreditMemoFactory.php
+++ b/Model/Order/CreditMemoFactory.php
@@ -27,10 +27,28 @@ class CreditMemoFactory extends \Magento\Sales\Model\Order\CreditmemoFactory
     {
         parent::initData($creditmemo, $data);
         if (isset($data['svea_handling_fee'])) {
-            $this->handlingFee->setBaseValue($creditmemo, (float)$data['svea_handling_fee']);
+            $amount = (float)$data['svea_handling_fee'];
+            $this->handlingFee->setValue($creditmemo, $amount);
+            $this->handlingFee->setBaseValue($creditmemo, $amount);
+        }
+        if (isset($data['svea_base_handling_fee'])) {
+            $baseAmount = (float)$data['svea_base_handling_fee'];
+            $this->handlingFee->setBaseValue($creditmemo, $baseAmount);
+            if (!isset($data['svea_handling_fee'])) {
+                $this->handlingFee->setValue($creditmemo, $baseAmount);
+            }
         }
         if (isset($data['svea_handling_fee_tax'])) {
-            $this->handlingFee->setTaxBaseValue($creditmemo, (float)$data['svea_handling_fee_tax']);
+            $taxAmount = (float)$data['svea_handling_fee_tax'];
+            $this->handlingFee->setTaxAmount($creditmemo, $taxAmount);
+            $this->handlingFee->setTaxBaseValue($creditmemo, $taxAmount);
+        }
+        if (isset($data['svea_base_handling_fee_tax'])) {
+            $baseTaxAmount = (float)$data['svea_base_handling_fee_tax'];
+            $this->handlingFee->setTaxBaseValue($creditmemo, $baseTaxAmount);
+            if (!isset($data['svea_handling_fee_tax'])) {
+                $this->handlingFee->setTaxAmount($creditmemo, $baseTaxAmount);
+            }
         }
         if (isset($data['svea_iban'])) {
             $creditmemo->setData('svea_iban', $data['svea_iban']);

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -30,4 +30,10 @@
         <column xsi:type="decimal" name="svea_base_handling_fee_tax" scale="4" precision="12" unsigned="false" nullable="true" comment="Svea Base Handling Fee Tax"/>
         <column xsi:type="decimal" name="svea_handling_fee_tax_percentage" scale="4" precision="12" unsigned="false" nullable="true" comment="Svea Handling Fee Tax Percentage"/>
     </table>
+    <table name="sales_creditmemo">
+        <column xsi:type="decimal" name="svea_handling_fee" scale="4" precision="12" unsigned="false" nullable="true" comment="Svea Handling Fee"/>
+        <column xsi:type="decimal" name="svea_base_handling_fee" scale="4" precision="12" unsigned="false" nullable="true" comment="Svea Base Handling Fee"/>
+        <column xsi:type="decimal" name="svea_handling_fee_tax" scale="4" precision="12" unsigned="false" nullable="true" comment="Svea Handling Fee Tax"/>
+        <column xsi:type="decimal" name="svea_base_handling_fee_tax" scale="4" precision="12" unsigned="false" nullable="true" comment="Svea Base Handling Fee Tax"/>
+    </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -31,5 +31,13 @@
             "svea_handling_fee_tax": true,
             "svea_base_handling_fee_tax": true
         }
+    },
+    "sales_creditmemo": {
+        "column": {
+            "svea_handling_fee": true,
+            "svea_base_handling_fee": true,
+            "svea_handling_fee_tax": true,
+            "svea_base_handling_fee_tax": true
+        }
     }
 }


### PR DESCRIPTION
Start persisting svea_handling_fee and svea_handling_fee_tax on credit memos so it can be displayed in admin interface. Fixes Issue #63, requires running setup:upgrade to do database migrations